### PR TITLE
open port

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,13 @@ resource "aws_security_group" "ec2_sg" {
   }
 
   ingress {
+    from_port   = 8032
+    to_port     = 8032
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
     from_port   = 5432
     to_port     = 5432
     protocol    = "tcp"


### PR DESCRIPTION
## Summary by Sourcery

Deployment:
- Open TCP port 8032 on EC2 security groups to allow external traffic.