### PR TITLE
add port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ aws.sh
 .idea
 
 .terraform.lock.hcl
+~

--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ resource "aws_key_pair" "ec2_key" {
 }
 
 resource "aws_security_group" "ec2_sg" {
-  name        = "ec2_security_group"
+  name        = "ec2_security_group_v2"
   description = "Allow SSH and HTTP traffic"
 
   ingress {
@@ -54,6 +54,13 @@ resource "aws_security_group" "ec2_sg" {
   ingress {
     from_port   = 8032
     to_port     = 8032
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 8033
+    to_port     = 8033
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }


### PR DESCRIPTION
## Summary by Sourcery

Rename AWS EC2 security group and add ingress rule for TCP port 8033

Enhancements:
- Rename EC2 security group resource to ec2_security_group_v2
- Add ingress rule to open TCP port 8033 on the security group