### PR TITLE
add ports

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "AWS_REGION" {
+  description = "The AWS region to deploy to."
+  type        = string
+}
+
 variable "POSTGRES_DB_NAME" {
   description = "PostgreSQL db name"
   type        = string
@@ -10,10 +15,5 @@ variable "POSTGRES_USERNAME" {
 
 variable "POSTGRES_PASSWORD" {
   description = "Password for the PostgreSQL user"
-  type        = string
-}
-
-variable "AWS_REGION" {
-  description = "aws region"
   type        = string
 }


### PR DESCRIPTION
## Summary by Sourcery

Expand network and data infrastructure by exposing new ports, introducing a DynamoDB table with corresponding IAM permissions, refactoring instance provisioning for Docker, and cleaning up Terraform configuration and outputs.

New Features:
- Introduce a DynamoDB table for transaction storage

Enhancements:
- Add multiple ingress rules to the EC2 security group for ports 4334, 4335, 4336, 8998, 8084, 9004, and 7888
- Refactor EC2 instance user data to install and enable Docker via systemd and enable rolling updates with user_data_replace_on_change
- Unify and relocate the PostgreSQL DB instance configuration and remove unused local variables
- Add outputs for the EC2 server public IP and refine the S3 bucket URL format and output descriptions
- Consolidate AWS_REGION variable definition in variables.tf